### PR TITLE
MNT: Add noarch: python

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,10 +16,10 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3
     - pip
   run:
-    - python
+    - python >=3
     - botocore >=1.12.36,<2.0.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,6 @@ requirements:
   run:
     - python
     - botocore >=1.12.36,<2.0.0
-    - futures >=2.2.0,<4.0.0  # [py2k]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
 
 requirements:
   host:
-    - python >=3
+    - python >=3  # Avoid a py2k selector for the futures dependency
     - pip
   run:
     - python >=3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
   sha256: 921a37e2aefc64145e7b73d50c71bb4f26f46e4c9f414dc648c6245ff92cf7db
 
 build:
+  noarch: python
   number: 2
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 2
+  number: 3
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 


### PR DESCRIPTION
This adds a couple of commits on top of - closes https://github.com/conda-forge/s3transfer-feedstock/pull/28 to get the linter working.